### PR TITLE
Add links

### DIFF
--- a/client/src/api/firebase.ts
+++ b/client/src/api/firebase.ts
@@ -23,6 +23,7 @@ export const getMessages = async (): Promise<Action[]> => {
         username: data.username,
         usernameShort: data.username.substring(0, 4),
         hashtag: data.hashtags?.[0],
+        link: data.links?.[0],
         mention: data.mentions?.[0],
         mentionShort: data.mentions?.[0]?.substring(0, 4),
       };
@@ -71,6 +72,7 @@ export const getMessagesByKey = async (key: string): Promise<Action[]> => {
         username: data.username,
         usernameShort: data.username.substring(0, 4),
         hashtag: data.hashtags?.[0],
+        link: data.links?.[0],
         mention: data.mentions?.[0],
         mentionShort: data.mentions?.[0]?.substring(0, 4),
       };

--- a/client/src/api/firebase.ts
+++ b/client/src/api/firebase.ts
@@ -28,7 +28,7 @@ export const getMessages = async (): Promise<Action[]> => {
         mentionShort: data.mentions?.[0]?.substring(0, 4),
       };
     })
-    .filter((action) => action.mention && action.hashtag)
+    .filter((action) => action.mention && (action.hashtag || action.link))
 }
 
 export const getMessagesByKey = async (key: string): Promise<Action[]> => {
@@ -77,7 +77,7 @@ export const getMessagesByKey = async (key: string): Promise<Action[]> => {
         mentionShort: data.mentions?.[0]?.substring(0, 4),
       };
     })
-    .filter((action) => action.mention && action.hashtag)
+    .filter((action) => action.mention && (action.hashtag || action.link))
 };
 
 export const addMessage = async (

--- a/client/src/components/action/index.tsx
+++ b/client/src/components/action/index.tsx
@@ -1,19 +1,21 @@
 import React from "react";
-import {Box, Text} from "grommet";
-import {Link} from "react-router-dom";
-import {Action} from "../../types";
+import { Box, Text } from "grommet";
+import { Link } from "react-router-dom";
+import { Action } from "../../types";
 
 export const UserAction = (props: { action: Action }) => {
-  const { action } = props
+  const { action } = props;
 
-  return <Box border={{ side: "bottom" }} pad={"4px 0"}>
-    <Text size={"small"}>
-      {action.timestamp} - {" "}
-      <Link className="link" to={`/0/${action.username}`}>0/{action.usernameShort}</Link>
-      {" tags #"}
-      {action.hashtag}
-      {" on "}
-      <Link className="link" to={`/0/${action.mention}`}>0/{action.mentionShort}</Link>
-    </Text>
-  </Box>
-}
+  return (
+    <Box border={{ side: "bottom" }} pad={"4px 0"}>
+      <Text size={"small"}>
+        {action.timestamp} - {" "}
+        <Link className="link" to={`/0/${action.username}`}>0/{action.usernameShort}</Link>
+        {action.hashtag ? ` tags #${action.hashtag}` : ` links ${action.link}`}
+        {" on "}
+        <Link className="link" to={`/0/${action.mention}`}>0/{action.mentionShort}</Link>
+      </Text>
+    </Box>
+  );
+};
+

--- a/client/src/pages/main/index.tsx
+++ b/client/src/pages/main/index.tsx
@@ -5,6 +5,7 @@ import '../../index.css'
 import {Action} from "../../types";
 import {UserAction} from "../../components/action";
 import {getMessages} from "../../api/firebase";
+import Typography from "antd/es/typography/Typography";
 
 export const MainPage = () => {
   const { key } = useParams();

--- a/client/src/pages/user/UserPage.tsx
+++ b/client/src/pages/user/UserPage.tsx
@@ -23,6 +23,7 @@ interface LinkItem {
 interface Message {
   id: string;
   hashtags?: string[];
+  link?: string[];
 }
 
 interface Action {

--- a/client/src/pages/user/UserPage.tsx
+++ b/client/src/pages/user/UserPage.tsx
@@ -30,6 +30,7 @@ interface Action {
   username: string;
   usernameShort: string;
   hashtag?: string;
+  link?: string;
   mention?: string;
   mentionShort?: string;
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -14,6 +14,7 @@ export interface Action {
   username: string;
   usernameShort: string;
   hashtag?: string;
+  link?: string;
   mention?: string;
   mentionShort?: string;
 }


### PR DESCRIPTION
Implemented the same feature for displaying hashtag mentions but for links.

- Modified Firebase "messages" collections structure (added "links" array field)
- Modified actions reducer (added "links (array)" and "link(string)"
- Change getMessages filter from only "action.mention && action.hashtag" -> "action.mention && (action.hashtag || action.link)"