### PR TITLE
link regex bug fix

### DIFF
--- a/client/src/pages/user/headerList.tsx
+++ b/client/src/pages/user/headerList.tsx
@@ -74,14 +74,16 @@ interface TitleClickEvent {
   providerName: string;
 }
 
+
 export const HeaderList = (props: HeaderListProps) => {
   const { userId: key, type, items, wallet, isUserPage } = props;
+  const addressWithoutPrefix = wallet ? wallet.address.slice(2) : '';
+
   const onHashSubmit = async (hashtag: string) => {
     if (!wallet || !key) {
       console.log("Invalid user wallet or key");
       return;
     }
-    const addressWithoutPrefix = wallet.address.slice(2);
     const submitText = `#${hashtag} @${key}`;
 
     await addMessageWithGeolocation(addressWithoutPrefix, submitText);
@@ -134,8 +136,6 @@ export const HeaderList = (props: HeaderListProps) => {
         console.log("Invalid user wallet or key");
         return;
       }
-
-      const addressWithoutPrefix = wallet.address.slice(2);
 
       await addMessageWithGeolocation(
         addressWithoutPrefix,

--- a/client/src/utils/social-url-parser.ts
+++ b/client/src/utils/social-url-parser.ts
@@ -24,22 +24,6 @@ export interface ParseResult {
     deprecated?: boolean;
 }
 
-const db = getFirestore();
-async function urlExistsInUserLinks(input: string, walletAddress: string) {
-    const docRef = doc(db, "userLinks", walletAddress);
-    const docSnap = await getDoc(docRef);
-
-    if (docSnap.exists()) {
-        const data = docSnap.data();
-        for (const key in data) {
-            if (typeof data[key] === 'object' && data[key].url === input) {
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
 function isLikelyURL(input: string) {
     return /^https?:\/\//.test(input) ||
            /^www\./.test(input) ||

--- a/client/src/utils/social-url-parser.ts
+++ b/client/src/utils/social-url-parser.ts
@@ -1,6 +1,4 @@
 import { regexes, RegexObject } from "../components/links";
-import { getFirestore, doc, getDoc } from "firebase/firestore";
-
 
 // function removeEmpty<T>(object: any): T {
 //     for (const key of Object.keys(object)) {

--- a/server/.env
+++ b/server/.env
@@ -1,4 +1,0 @@
-AUTH0_DOMAIN=dev-j4t5eeehosnfkpcf.us.auth0.com
-AUTH0_CLIENT_ID=y8JwYhx0JkiKCbfikRTFGTNaTy7CUpnA
-AUTH0_CLIENT_SECRET=kHsebW2ZSh_iz8ZM1edhCDO6mKoFN7K0w3RuaSSuXYJGQLp7EoxTFCWaPUR9gATh
-AUTH0_CALLBACK_URL=http://localhost:3000/auth/openid-callback


### PR DESCRIPTION
**Fixed the following bugs when clicking on big '/':**

- If the domain already matched predefined domains, it would sometimes not correctly replace those predefined texts but instead create new text links due to regex issues
- When "www." was not entered in URLs, it would sometime not be recognized properly due to regex issues
- If domain was correctly matched with one of the predefined domains, it would show the domain name as well (eg. "twitter.com/stse" -> "twitter/stse") due to using same single function "extractUsernameFromURL()" which was originally created for undefined custom links. Implemented separate function "extractUsernameForProvider()" to account for this case.
